### PR TITLE
fix:levelによる絞り込みが効いていなかったため修正した

### DIFF
--- a/go/src/usecase/vocabulary_usecase.go
+++ b/go/src/usecase/vocabulary_usecase.go
@@ -21,12 +21,10 @@ func (s Usecase) GetAll(input *ListInput) ([]Vocabulary, error) {
 	orm := detDb.Model(&Vocabulary{})
 
 	if *input.Level != "" {
-		orm = detDb.Model(&Vocabulary{}).Where("level = ?", input.Level).Order("RANDOM()").Limit(30)
-	} else {
-		orm = detDb.Model(&Vocabulary{}).Order("RANDOM()").Limit(30)
+		orm = orm.Where("level = ?", input.Level)
 	}
 
-	if err := orm.Find(&u).Error; err != nil {
+	if err := orm.Order("RANDOM()").Limit(30).Find(&u).Error; err != nil {
 		return nil, err
 	}
 	return u, nil


### PR DESCRIPTION
🎉人生初GoのPRです🎉

見てみた感じ、クエリパラメータはこんな感じでした、
- 指定なしの場合：空文字
- 指定ありの場合：string? text?

そこで、空文字じゃなければwhere, 他は全件にしてみました。
初のGoなので書き方にあまりじしんがない。。笑

書き方あってるかとか見ていただけると幸いっす。

### レスポンス
level指定したとき
<img width="939" alt="Screenshot 2023-02-09 at 23 58 24" src="https://user-images.githubusercontent.com/69615045/217848749-91aa645a-4d6d-4eb2-b24d-dd6ec1f28b85.png">

ないとき
<img width="939" alt="Screenshot 2023-02-09 at 23 58 42" src="https://user-images.githubusercontent.com/69615045/217848762-52eb75de-d647-4a27-9b0a-4f44958b19c1.png">
